### PR TITLE
Moderation Refactor

### DIFF
--- a/commands/README.md
+++ b/commands/README.md
@@ -95,6 +95,8 @@ Moderation Commands
  - `joinphrase set, [user], [phrase]` - Set a joinphrase
  - `joinphrase delete, [user]` - Remove a joinphrase
  - `vjf` - View joinphrases list
+ 
+**Note:** Excepted users can use moderation commands in format `command [roomid]Arguments` to set moderation through PM or other room. Example: `ab [lobby]spammer1, spammer2`
 
 Battle Commands
 ------------

--- a/commands/moderation.js
+++ b/commands/moderation.js
@@ -38,6 +38,15 @@ function unblacklistRegex(regex, room) {
 	return false;
 }
 
+function getTargetRoom(arg) {
+	if (!arg) return null;
+	if (arg.indexOf("[") !== 0) return null;
+	if (arg.indexOf("]") < 0) return null;
+	var target = toRoomid(arg.substr(arg.indexOf("[") + 1, arg.indexOf("]") - arg.indexOf("[") - 1));
+	var newArg = arg.substr(arg.indexOf("]") + 1);
+	return {arg: newArg, room: target};
+}
+
 Settings.addPermissions(['autoban', 'banword', 'joinphrase']);
 
 exports.commands = {
@@ -50,8 +59,16 @@ exports.commands = {
 	ab: 'autoban',
 	autoban: function (arg, by, room, cmd) {
 		if (!this.can('autoban')) return;
-		if (this.roomType !== 'chat') return this.reply(this.trad('notchat'));
-		if (!this.botRanked('@')) return this.reply(Bot.status.nickName + " " + this.trad('notmod'));
+		var tarRoom = room;
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+		if (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat') return this.reply(this.trad('notchat') + textHelper);
+		if (!this.isExcepted && !this.botRanked('@')) return this.reply(this.botName + " " + this.trad('notmod'));
 
 		var added = [];
 		var illegalNick = [];
@@ -67,11 +84,11 @@ exports.commands = {
 				illegalNick.push(tarUser);
 				continue;
 			}
-			if (!blacklistUser(tarUser, room)) {
+			if (!blacklistUser(tarUser, tarRoom)) {
 				alreadyAdded.push(tarUser);
 				continue;
 			}
-			this.reply('/roomban ' + tarUser + ', ' + this.trad('bu'));
+			this.say(tarRoom, '/roomban ' + tarUser + ', ' + this.trad('bu'));
 			added.push(tarUser);
 		}
 
@@ -84,7 +101,7 @@ exports.commands = {
 		}
 		if (alreadyAdded.length) text += this.trad('u') + ' "' + alreadyAdded.join('", "') + '" ' + this.trad('already') + ' ';
 		if (illegalNick.length) text += this.trad('all') + ' ' + (text.length ? (this.trad('other') + ' ') : '') + ' ' + this.trad('illegal');
-		if (mn.length) this.reply("/mn " + text + " | By: " + by);
+		if (mn.length && (!Config.moderation || !Config.moderation.disableModNote)) this.say(tarRoom, "/mn " + text + " | By: " + by);
 		this.reply(text);
 	},
 
@@ -93,8 +110,16 @@ exports.commands = {
 	unab: 'unautoban',
 	unautoban: function (arg, by, room, cmd) {
 		if (!this.can('autoban')) return;
-		if (this.roomType !== 'chat') return this.reply(this.trad('notchat'));
-		if (!this.botRanked('@')) return this.reply(Bot.status.nickName + " " + this.trad('notmod'));
+		var tarRoom = room;
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+		if (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat') return this.reply(this.trad('notchat') + textHelper);
+		if (!this.isExcepted && !this.botRanked('@')) return this.reply(this.botName + " " + this.trad('notmod'));
 
 		arg = arg.split(',');
 
@@ -109,11 +134,11 @@ exports.commands = {
 				notRemoved.push(tarUser);
 				continue;
 			}
-			if (!unblacklistUser(tarUser, room)) {
+			if (!unblacklistUser(tarUser, tarRoom)) {
 				notRemoved.push(tarUser);
 				continue;
 			}
-			this.reply('/roomunban ' + tarUser);
+			this.say(tarRoom, '/roomunban ' + tarUser);
 			removed.push(tarUser);
 		}
 
@@ -129,42 +154,58 @@ exports.commands = {
 	rab: 'regexautoban',
 	regexautoban: function (arg, user, room) {
 		if (!this.can('autoban')) return;
-		if (this.roomType !== 'chat') return this.reply(this.trad('notchat'));
-		if (!this.botRanked('@')) return this.reply(Bot.status.nickName + " " + this.trad('notmod'));
+		var tarRoom = room;
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+		if (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat') return this.reply(this.trad('notchat') + textHelper);
+		if (!this.isExcepted && !this.botRanked('@')) return this.reply(Bot.status.nickName + " " + this.trad('notmod'));
 
-		if (!arg) return this.say(room, this.trad('notarg'));
+		if (!arg) return this.reply(this.trad('notarg'));
 
 		try {
 			var testing = new RegExp(arg, 'i');
 		} catch (e) {
-			return this.say(room, e.message);
+			return this.reply(e.message);
 		}
 
 		if (/^(?:(?:\.+|[a-z0-9]|\\[a-z0-9SbB])(?![a-z0-9\.\\])(?:\*|\{\d+\,(?:\d+)?\}))+$/i.test(arg)) {
-			return this.say(room, this.trad('re') + ' /' + arg + '/i ' + this.trad('notadd'));
+			return this.reply(this.trad('re') + ' /' + arg + '/i ' + this.trad('notadd'));
 		}
 
 		var regex = '/' + arg + '/i';
-		if (!blacklistRegex(regex, room)) return this.say(room, '/' + regex + '/ ' + this.trad('already'));
+		if (!blacklistRegex(regex, tarRoom)) return this.reply('/' + regex + '/ ' + this.trad('already'));
 		Settings.save();
-		this.say(room, '/modnote ' + this.trad('re') + ' ' + regex + ' ' + this.trad('addby') + ' ' + user + '.');
-		this.say(room, this.trad('re') + ' ' + regex + ' ' + this.trad('add'));
+		if (!Config.moderation || !Config.moderation.disableModNote) this.say(tarRoom, '/modnote ' + this.trad('re') + ' ' + regex + ' ' + this.trad('addby') + ' ' + user + '.');
+		this.reply(this.trad('re') + ' ' + regex + ' ' + this.trad('add'));
 	},
 
 	unrab: 'unregexautoban',
 	unregexautoban: function (arg, user, room) {
 		if (!this.can('autoban')) return;
-		if (this.roomType !== 'chat') return this.reply(this.trad('notchat'));
-		if (!this.botRanked('@')) return this.reply(Bot.status.nickName + " " + this.trad('notmod'));
+		var tarRoom = room;
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+		if (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat') return this.reply(this.trad('notchat') + textHelper);
+		if (!this.isExcepted && !this.botRanked('@')) return this.reply(Bot.status.nickName + " " + this.trad('notmod'));
 
-		if (!arg) return this.say(room, this.trad('notarg'));
+		if (!arg) return this.reply(this.trad('notarg'));
 
 		arg = '/' + arg.replace(/\\\\/g, '\\') + '/i';
-		if (!unblacklistRegex(arg, room)) return this.say(room, this.trad('re') + ' ' + arg + ' ' + this.trad('notpresent'));
+		if (!unblacklistRegex(arg, tarRoom)) return this.reply(this.trad('re') + ' ' + arg + ' ' + this.trad('notpresent'));
 
 		Settings.save();
-		this.say(room, '/modnote ' + this.trad('re') + ' ' + arg + ' ' + this.trad('rby') + ' ' + user + '.');
-		this.say(room, this.trad('re') + ' ' + arg + ' ' + this.trad('r'));
+		if (!Config.moderation || !Config.moderation.disableModNote) this.say(tarRoom, '/modnote ' + this.trad('re') + ' ' + arg + ' ' + this.trad('rby') + ' ' + user + '.');
+		this.reply(this.trad('re') + ' ' + arg + ' ' + this.trad('r'));
 	},
 
 	viewbans: 'viewblacklist',
@@ -172,35 +213,43 @@ exports.commands = {
 	viewautobans: 'viewblacklist',
 	viewblacklist: function (arg, by, room, cmd) {
 		if (!this.can('autoban')) return;
-		if (this.roomType !== 'chat') return this.reply(this.trad('notchat'));
+		var tarRoom = room;
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+		if (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat') return this.reply(this.trad('notchat') + textHelper);
 
 		var text = '';
 		var nBans = 0;
 
 		if (arg.length) {
-			if (Settings.settings['autoban'] && Settings.settings['autoban'][room]) {
+			if (Settings.settings['autoban'] && Settings.settings['autoban'][tarRoom]) {
 				var nick = toId(arg);
 				if (nick.length < 1 || nick.length > 18) {
 					return this.pmReply(this.trad('iu') + ': "' + nick + '".');
 				} else {
-					return this.pmReply(this.trad('u') + ' "' + nick + '" ' + this.trad('currently') + ' ' + (nick in Settings.settings['autoban'][room] ? '' : (this.trad('not') + ' ')) + this.trad('b') + ' ' + room + '.');
+					return this.pmReply(this.trad('u') + ' "' + nick + '" ' + this.trad('currently') + ' ' + (nick in Settings.settings['autoban'][tarRoom] ? '' : (this.trad('not') + ' ')) + this.trad('b') + ' ' + tarRoom + '.');
 				}
 			} else {
-				return this.pmReply(this.trad('nousers') + ' ' + room);
+				return this.pmReply(this.trad('nousers') + ' ' + tarRoom);
 			}
 		}
 
-		if (Settings.settings['autoban'] && Settings.settings['autoban'][room]) {
-			text += this.trad('listab') + ' ' + room + ':\n\n';
-			for (var i in Settings.settings['autoban'][room]) {
+		if (Settings.settings['autoban'] && Settings.settings['autoban'][tarRoom]) {
+			text += this.trad('listab') + ' ' + tarRoom + ':\n\n';
+			for (var i in Settings.settings['autoban'][tarRoom]) {
 				text += i + "\n";
 				nBans++;
 			}
 		}
 
-		if (Settings.settings['regexautoban'] && Settings.settings['regexautoban'][room]) {
-			text += '\n' + this.trad('listrab') + ' ' + room + ':\n\n';
-			for (var i in Settings.settings['regexautoban'][room]) {
+		if (Settings.settings['regexautoban'] && Settings.settings['regexautoban'][tarRoom]) {
+			text += '\n' + this.trad('listrab') + ' ' + tarRoom + ':\n\n';
+			for (var i in Settings.settings['regexautoban'][tarRoom]) {
 				text += i + "\n";
 				nBans++;
 			}
@@ -212,7 +261,7 @@ exports.commands = {
 				else this.pmReply(this.trad('err'));
 			}.bind(this));
 		} else {
-			this.pmReply(this.trad('nousers') + ' ' + room);
+			this.pmReply(this.trad('nousers') + ' ' + tarRoom);
 		}
 	},
 
@@ -222,50 +271,69 @@ exports.commands = {
 
 	banphrase: 'banword',
 	banword: function (arg, user, room) {
-		arg = arg.trim().toLowerCase();
+		if (!this.can('banword')) return;
 		if (!arg) return false;
 
-		var tarRoom = room;
+		var tarRoom;
 		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
+			if (!this.isRanked('~')) return false;
 			tarRoom = 'global';
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			tarRoom = room;
 		} else {
-			return false;
+			tarRoom = room;
 		}
+
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
+		arg = arg.trim().toLowerCase();
 
 		var bannedPhrases = Settings.settings['bannedphrases'] ? Settings.settings['bannedphrases'][tarRoom] : null;
 		if (!bannedPhrases) {
 			if (bannedPhrases === null) Settings.settings['bannedphrases'] = {};
 			bannedPhrases = (Settings.settings['bannedphrases'][tarRoom] = {});
 		} else if (bannedPhrases[arg]) {
-			return this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('already'));
+			return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('already') + textHelper);
 		}
 		bannedPhrases[arg] = 1;
 
 		Settings.save();
-		this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('ban'));
+		this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('ban') + textHelper);
 	},
 
 	unbanphrase: 'unbanword',
 	unbanword: function (arg, user, room) {
+		if (!this.can('banword')) return;
+		if (!arg) return false;
+
 		var tarRoom;
 		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
+			if (!this.isRanked('~')) return false;
 			tarRoom = 'global';
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			tarRoom = room;
 		} else {
-			return false;
+			tarRoom = room;
 		}
 
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
 		arg = arg.trim().toLowerCase();
-		if (!arg) return false;
-		if (!Settings.settings['bannedphrases']) return this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('not'));
+
+		if (!Settings.settings['bannedphrases']) return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('not') + textHelper);
 
 		var bannedPhrases = Settings.settings['bannedphrases'][tarRoom];
-		if (!bannedPhrases || !bannedPhrases[arg]) return this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('not'));
+		if (!bannedPhrases || !bannedPhrases[arg]) return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('not') + textHelper);
 
 		delete bannedPhrases[arg];
 		if (Object.isEmpty(bannedPhrases)) {
@@ -274,90 +342,117 @@ exports.commands = {
 		}
 
 		Settings.save();
-		this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('unban'));
+		this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('unban') + textHelper);
 	},
 
 	viewbannedphrases: 'viewbannedwords',
 	vbw: 'viewbannedwords',
 	viewbannedwords: function (arg, user, room) {
-		var tarRoom = room;
+		if (!this.can('banword')) return;
+		var tarRoom;
 		var text = '';
 		var bannedFrom = '';
 		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
+			if (!this.isRanked('~')) return false;
 			tarRoom = 'global';
-			bannedFrom += this.trad('globally');
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			text += '/pm ' + user + ', ';
-			bannedFrom += this.trad('in') + ' ' + room;
 		} else {
-			return false;
+			tarRoom = room;
+		}
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
 		}
 
-		if (!Settings.settings['bannedphrases']) return this.say(room, text + this.trad('nowords'));
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
+
+		if (tarRoom === 'global') bannedFrom += this.trad('globally');
+		else bannedFrom += this.trad('in') + ' ' + tarRoom;
+
+		if (!Settings.settings['bannedphrases']) return this.reply(this.trad('nowords') + textHelper);
 		var bannedPhrases = Settings.settings['bannedphrases'][tarRoom];
-		if (!bannedPhrases) return this.say(room, text + this.trad('nowords'));
+		if (!bannedPhrases) return this.reply(this.trad('nowords') + textHelper);
 
 		if (arg.length) {
-			text += this.trad('phrase') + ' "' + arg + '" ' + this.trad('curr') + ' ' + (bannedPhrases[arg] ? '' : (this.trad('not') + ' ')) + this.trad('banned') + ' ' + bannedFrom + '.';
-			return this.say(room, text);
+			return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('curr') + ' ' + (bannedPhrases[arg] ? '' : (this.trad('not') + ' ')) + this.trad('banned') + ' ' + bannedFrom + '.');
 		}
 
 		var banList = Object.keys(bannedPhrases);
-		if (!banList.length) return this.say(room, text + this.trad('nowords'));
+		if (!banList.length) return this.reply(this.trad('nowords') + textHelper);
 
 		Tools.uploadToHastebin(this.trad('list') + ' ' + bannedFrom + ':\n\n' + banList.join('\n'), function (r, link) {
-			if (r) return this.say(room, text + this.trad('link') + ' ' + bannedFrom + ': ' + link);
+			if (r) return this.pmReply(this.trad('link') + ' ' + bannedFrom + ': ' + link);
 			else this.pmReply(this.trad('err'));
 		}.bind(this));
 	},
 
 	inapropiatephrase: 'inapword',
 	inapword: function (arg, user, room) {
-		arg = arg.trim().toLowerCase();
+		if (!this.can('banword')) return;
 		if (!arg) return false;
 
-		var tarRoom = room;
+		var tarRoom;
 		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
+			if (!this.isRanked('~')) return false;
 			tarRoom = 'global';
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			tarRoom = room;
 		} else {
-			return false;
+			tarRoom = room;
 		}
+
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
+		arg = arg.trim().toLowerCase();
 
 		var bannedPhrases = Settings.settings['inapropiatephrases'] ? Settings.settings['inapropiatephrases'][tarRoom] : null;
 		if (!bannedPhrases) {
 			if (bannedPhrases === null) Settings.settings['inapropiatephrases'] = {};
 			bannedPhrases = (Settings.settings['inapropiatephrases'][tarRoom] = {});
 		} else if (bannedPhrases[arg]) {
-			return this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('already'));
+			return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('already') + textHelper);
 		}
 		bannedPhrases[arg] = 1;
 
 		Settings.save();
-		this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('ban'));
+		this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('ban') + textHelper);
 	},
 
 	uninapropiatephrase: 'uninapword',
 	uninapword: function (arg, user, room) {
+		if (!this.can('banword')) return;
+		if (!arg) return false;
+
 		var tarRoom;
 		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
+			if (!this.isRanked('~')) return false;
 			tarRoom = 'global';
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			tarRoom = room;
 		} else {
-			return false;
+			tarRoom = room;
 		}
 
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
 		arg = arg.trim().toLowerCase();
-		if (!arg) return false;
-		if (!Settings.settings['inapropiatephrases']) return this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('not'));
+
+		if (!Settings.settings['inapropiatephrases']) return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('not') + textHelper);
 
 		var bannedPhrases = Settings.settings['inapropiatephrases'][tarRoom];
-		if (!bannedPhrases || !bannedPhrases[arg]) return this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('not'));
+		if (!bannedPhrases || !bannedPhrases[arg]) return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('not') + textHelper);
 
 		delete bannedPhrases[arg];
 		if (Object.isEmpty(bannedPhrases)) {
@@ -366,40 +461,48 @@ exports.commands = {
 		}
 
 		Settings.save();
-		this.say(room, this.trad('phrase') + ' "' + arg + '" ' + this.trad('unban'));
+		this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('unban') + textHelper);
 	},
 
 	viewinapropiatephrases: 'viewinapwords',
 	viw: 'viewinapwords',
 	viewinapwords: function (arg, user, room) {
-		var tarRoom = room;
+		if (!this.can('banword')) return;
+		var tarRoom;
 		var text = '';
 		var bannedFrom = '';
 		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
+			if (!this.isRanked('~')) return false;
 			tarRoom = 'global';
-			bannedFrom += 'globally';
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			text += '/pm ' + user + ', ';
-			bannedFrom += 'in ' + room;
 		} else {
-			return false;
+			tarRoom = room;
+		}
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
 		}
 
-		if (!Settings.settings['inapropiatephrases']) return this.say(room, text + this.trad('nowords'));
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
+
+		if (tarRoom === 'global') bannedFrom += this.trad('globally');
+		else bannedFrom += this.trad('in') + ' ' + tarRoom;
+
+		if (!Settings.settings['inapropiatephrases']) return this.reply(this.trad('nowords') + textHelper);
 		var bannedPhrases = Settings.settings['inapropiatephrases'][tarRoom];
-		if (!bannedPhrases) return this.say(room, text + this.trad('nowords'));
+		if (!bannedPhrases) return this.reply(this.trad('nowords') + textHelper);
 
 		if (arg.length) {
-			text += this.trad('phrase') + ' "' + arg + '" ' + this.trad('curr') + ' ' + (bannedPhrases[arg] || (this.trad('not') + ' ')) + this.trad('banned') + ' ' + bannedFrom + '.';
-			return this.say(room, text);
+			return this.reply(this.trad('phrase') + ' "' + arg + '" ' + this.trad('curr') + ' ' + (bannedPhrases[arg] || (this.trad('not') + ' ')) + this.trad('banned') + ' ' + bannedFrom + '.');
 		}
 
 		var banList = Object.keys(bannedPhrases);
-		if (!banList.length) return this.say(room, text + this.trad('nowords'));
+		if (!banList.length) return this.reply(this.trad('nowords') + textHelper);
 
 		Tools.uploadToHastebin(this.trad('list') + ' ' + bannedFrom + ':\n\n' + banList.join('\n'), function (r, link) {
-			if (r) return this.say(room, text + this.trad('link') + ' ' + bannedFrom + ': ' + link);
+			if (r) return this.pmReply(this.trad('link') + ' ' + bannedFrom + ': ' + link);
 			else this.pmReply(this.trad('err'));
 		}.bind(this));
 	},
@@ -413,28 +516,45 @@ exports.commands = {
 		if (!this.can('joinphrase')) return;
 		if (!Settings.settings['joinphrases']) Settings.settings['joinphrases'] = {};
 
-		if (this.roomType === 'chat' && toId(arg) in {'on': 1, 'enable': 1}) {
-			if (!this.isRanked('#')) return false;
-			if (!Settings.settings['jpdisable']) Settings.settings['jpdisable'] = {};
-			if (Settings.settings['jpdisable'][room]) delete Settings.settings['jpdisable'][room];
-			else return this.reply(this.trad('ae'));
-			Settings.save();
-			return this.reply(this.trad('e'));
+		var tarRoom;
+		if (this.roomType === 'pm') {
+			if (!this.isRanked('~')) return false;
+			tarRoom = 'global';
+		} else {
+			tarRoom = room;
 		}
 
-		if (this.roomType === 'chat' && toId(arg) in {'off': 1, 'disable': 1}) {
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
+
+		if (Bot.rooms[tarRoom] && Bot.rooms[tarRoom].type === 'chat' && toId(arg) in {'on': 1, 'enable': 1}) {
 			if (!this.isRanked('#')) return false;
 			if (!Settings.settings['jpdisable']) Settings.settings['jpdisable'] = {};
-			if (!Settings.settings['jpdisable'][room]) Settings.settings['jpdisable'][room] = 1;
-			else return this.reply(this.trad('ad'));
+			if (Settings.settings['jpdisable'][tarRoom]) delete Settings.settings['jpdisable'][tarRoom];
+			else return this.reply(this.trad('ae') + textHelper);
 			Settings.save();
-			return this.reply(this.trad('d'));
+			return this.reply(this.trad('e') + textHelper);
+		}
+
+		if (Bot.rooms[tarRoom] && Bot.rooms[tarRoom].type === 'chat' && toId(arg) in {'off': 1, 'disable': 1}) {
+			if (!this.isRanked('#')) return false;
+			if (!Settings.settings['jpdisable']) Settings.settings['jpdisable'] = {};
+			if (!Settings.settings['jpdisable'][tarRoom]) Settings.settings['jpdisable'][tarRoom] = 1;
+			else return this.reply(this.trad('ad') + textHelper);
+			Settings.save();
+			return this.reply(this.trad('d') + textHelper);
 		}
 
 		var args = arg.split(",");
 
 		if (args.length < 2) return this.reply(this.trad('u1') + ": " + this.cmdToken + cmd + " " + this.trad('u2'));
-		if (Settings.settings['jpdisable'] && Settings.settings['jpdisable'][room]) return this.reply(this.trad('dis'));
+		if (Settings.settings['jpdisable'] && Settings.settings['jpdisable'][tarRoom]) return this.reply(this.trad('dis') + textHelper);
 
 		if (toId(args[0]) !== "delete" && args.length === 2) {
 			arg = "set," + toId(args[0]) + "," + arg.substr(args[0].length + 1);
@@ -447,16 +567,6 @@ exports.commands = {
 		var user = toId(args[1]);
 		if (!user) return false;
 
-		var tarRoom;
-		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
-			tarRoom = 'global';
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			tarRoom = room;
-		} else {
-			return false;
-		}
-
 		switch (toId(args[0])) {
 			case 'set':
 			case 'add':
@@ -466,14 +576,14 @@ exports.commands = {
 				if (!Settings.settings['joinphrases'][tarRoom]) Settings.settings['joinphrases'][tarRoom] = {};
 				Settings.settings['joinphrases'][tarRoom][user] = Tools.stripCommands(arg);
 				Settings.save();
-				this.reply(this.trad('jpfor') + " " + user + ' ' + this.trad('modified') + ' ' + ((tarRoom === 'global') ? this.trad('globally') : this.trad('forthis')));
+				this.reply(this.trad('jpfor') + " " + user + ' ' + this.trad('modified') + ' ' + ((tarRoom === 'global') ? this.trad('globally') : (this.trad('forthis') + textHelper)));
 				break;
 			case 'delete':
 				if (!Settings.settings['joinphrases'][tarRoom]) Settings.settings['joinphrases'][tarRoom] = {};
-				if (!Settings.settings['joinphrases'][tarRoom][user]) return this.reply(this.trad('jpfor') + " " + user + " " + this.trad('not') + " " + ((tarRoom === 'global') ? this.trad('globally') : this.trad('forthis')));
+				if (!Settings.settings['joinphrases'][tarRoom][user]) return this.reply(this.trad('jpfor') + " " + user + " " + this.trad('not') + " " + ((tarRoom === 'global') ? this.trad('globally') : (this.trad('forthis') + textHelper)));
 				delete Settings.settings['joinphrases'][tarRoom][user];
 				Settings.save();
-				this.reply(this.trad('jpfor') + " " + user + ' ' + this.trad('del') + ' ' + ((tarRoom === 'global') ? this.trad('globally') : this.trad('forthis')));
+				this.reply(this.trad('jpfor') + " " + user + ' ' + this.trad('del') + ' ' + ((tarRoom === 'global') ? this.trad('globally') : (this.trad('forthis') + textHelper)));
 				break;
 			default:
 				return this.reply(this.trad('u1') + ": " + this.cmdToken + cmd + " " + this.trad('u2'));
@@ -484,17 +594,25 @@ exports.commands = {
 	viewjoinphrases: function (arg, by, room, cmd) {
 		if (!this.can('joinphrase')) return;
 		if (!Settings.settings['joinphrases']) Settings.settings['joinphrases'] = {};
-		arg = toId(arg);
 
 		var tarRoom;
 		if (this.roomType === 'pm') {
-			if (!this.isExcepted()) return false;
+			if (!this.isRanked('~')) return false;
 			tarRoom = 'global';
-		} else if (this.can('banword') && this.roomType === 'chat') {
-			tarRoom = room;
 		} else {
-			return false;
+			tarRoom = room;
 		}
+
+		var targetObj = getTargetRoom(arg);
+		var textHelper = '';
+		if (targetObj && this.isExcepted) {
+			arg = targetObj.arg;
+			tarRoom = targetObj.room;
+			textHelper = ' (' + tarRoom + ')';
+		}
+		if (tarRoom !== 'global' && (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat')) return this.reply(this.trad('notchat') + textHelper);
+
+		arg = toId(arg);
 
 		if (!Settings.settings['joinphrases'][tarRoom]) Settings.settings['joinphrases'][tarRoom] = {};
 
@@ -508,9 +626,9 @@ exports.commands = {
 		for (var i in Settings.settings['joinphrases'][tarRoom]) {
 			List.push(i + " => " + Settings.settings['joinphrases'][tarRoom][i]);
 		}
-		if (!List.length) return this.reply(this.trad('empty'));
-		Tools.uploadToHastebin(this.trad('jp') + " " + (tarRoom === 'global' ? this.trad('globally') : (this.trad('in') + " " + room)) + ":\n\n" + List.join('\n'), function (r, link) {
-			if (r) return this.pmReply(this.trad('jp') + ' ' + (tarRoom === 'global' ? this.trad('globally') : (this.trad('in') + " " + room)) + ': ' + link);
+		if (!List.length) return this.reply(this.trad('empty') + textHelper);
+		Tools.uploadToHastebin(this.trad('jp') + " " + (tarRoom === 'global' ? this.trad('globally') : (this.trad('in') + " " + tarRoom)) + ":\n\n" + List.join('\n'), function (r, link) {
+			if (r) return this.pmReply(this.trad('jp') + ' ' + (tarRoom === 'global' ? this.trad('globally') : (this.trad('in') + " " + tarRoom)) + ': ' + link);
 			else this.pmReply(this.trad('err'));
 		}.bind(this));
 	},
@@ -524,13 +642,13 @@ exports.commands = {
 	modsettings: 'mod',
 	mod: function (arg, by, room, cmd) {
 		if (!this.isRanked('#')) return false;
-		var targetRoom = room;
+		var tarRoom = room;
 		var args = arg.split(",");
 		if (args.length > 2) {
 			if (!this.isRanked('~')) return false;
-			targetRoom = toId(args[0]);
+			tarRoom = toRoomid(args[0]);
 		}
-		if (!Bot.rooms[targetRoom] || Bot.rooms[targetRoom].type !== 'chat') return this.reply(this.trad('notchat'));
+		if (!Bot.rooms[tarRoom] || Bot.rooms[tarRoom].type !== 'chat') return this.reply(this.trad('notchat') + ' (' + tarRoom + ')');
 		var modTable = {
 			'caps': 1,
 			'stretching': 1,
@@ -550,23 +668,23 @@ exports.commands = {
 		if (!(mod in modTable)) return this.reply(this.trad('valid') + ": " + Object.keys(modTable).sort().join(", "));
 
 		if (!Settings.settings['modding']) Settings.settings['modding'] = {};
-		if (!Settings.settings['modding'][targetRoom]) Settings.settings['modding'][targetRoom] = {};
+		if (!Settings.settings['modding'][tarRoom]) Settings.settings['modding'][tarRoom] = {};
 
 		if (set === 'on') {
-			if (Settings.settings['modding'][targetRoom][mod] === 1) {
-				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('ae') + ' ' + targetRoom);
+			if (Settings.settings['modding'][tarRoom][mod] === 1) {
+				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('ae') + ' ' + tarRoom);
 			} else {
-				Settings.settings['modding'][targetRoom][mod] = 1;
+				Settings.settings['modding'][tarRoom][mod] = 1;
 				Settings.save();
-				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('e') + ' ' + targetRoom);
+				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('e') + ' ' + tarRoom);
 			}
 		} else {
-			if (Settings.settings['modding'][targetRoom][mod] === 0) {
-				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('ad') + ' ' + targetRoom);
+			if (Settings.settings['modding'][tarRoom][mod] === 0) {
+				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('ad') + ' ' + tarRoom);
 			} else {
-				Settings.settings['modding'][targetRoom][mod] = 0;
+				Settings.settings['modding'][tarRoom][mod] = 0;
 				Settings.save();
-				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('d') + ' ' + targetRoom);
+				this.reply(this.trad('mod') + " **" + mod + "** " + this.trad('d') + ' ' + tarRoom);
 			}
 		}
 	}

--- a/config-example.js
+++ b/config-example.js
@@ -150,7 +150,10 @@ exports.moderation = {
 		'psservers': 1,
 
 		//multiple infraction
-		'multiple': 1
+		'multiple': 1,
+
+		//zero tolerance
+		'zerotol': 1
 	},
 
 	punishments: [
@@ -163,6 +166,13 @@ exports.moderation = {
 	psServersExcepts: {
 		"showdown": 1,
 		"smogtours": 1
+	},
+
+	zeroToleranceDefaultLevel: 'h',
+	zeroToleranceLevels: {
+		'l': {name: 'Low', value: 1},
+		'n': {name: 'Normal', value: 2},
+		'h': {name: 'High', value: 3},
 	}
 };
 

--- a/config-example.js
+++ b/config-example.js
@@ -122,6 +122,18 @@ exports.moderation = {
 	allowmute: true,
 	disableModNote: false,
 
+	MOD_CONSTS: {
+		FLOOD_MESSAGE_NUM: 5,
+		FLOOD_PER_MSG_MIN: 500, // this is the minimum time between messages for legitimate spam. It's used to determine what "flooding" is caused by lag
+		FLOOD_MESSAGE_TIME: 6 * 1000,
+
+		MIN_CAPS_LENGTH: 18,
+		MIN_CAPS_PROPORTION: 0.8,
+
+		MAX_STRETCH: 7,
+		MAX_REPEAT: 4
+	},
+
 	modDefault: {
 		//basic mods
 		'caps': 1,

--- a/config-example.js
+++ b/config-example.js
@@ -120,6 +120,7 @@ exports.moderation = {
 	modException: '%', // Min rank for not receive moderation
 
 	allowmute: true,
+	disableModNote: false,
 
 	modDefault: {
 		//basic mods

--- a/config-example.js
+++ b/config-example.js
@@ -172,7 +172,7 @@ exports.moderation = {
 	zeroToleranceLevels: {
 		'l': {name: 'Low', value: 1},
 		'n': {name: 'Normal', value: 2},
-		'h': {name: 'High', value: 3},
+		'h': {name: 'High', value: 3}
 	}
 };
 

--- a/features/moderation/README.md
+++ b/features/moderation/README.md
@@ -1,0 +1,108 @@
+﻿Pokemon Showdown Bot - Moderation Feature
+====================
+
+This feature deals with caps, stretching, flooding, spam and other usual infractions. Note that the bot can't think, so it will probably make mistakes. Also, this feature has Join Phrases, which consists of a kind of greeting that the bot says when an user joins a room.
+
+Moderation Commands
+------------
+
+**Mod Settings:** Use `mod (room - optional), [moderation], [on/off]` to enable or disable moderations.
+
+**Autoban**
+ - `ab [user], [user]...` - Add users to blacklist
+ - `unab [user], [user]...` - Remove users from blacklist
+ - `rab [regex]` - Regex ban
+ - `unrab [regex]` - Remove a regex ban
+ - `vab` - View blacklist
+
+**Zero Tolerance**
+
+**Banwords and InapropiateWords:** Saying this words means automute. InapropiateWords requires that words are separated.
+ - `banword [phrase]` - Add a banword
+ - `unbanword [phrase]` - Remove a banword
+ - `vbw` - View banword list
+ - `inapword [phrase]` - Add an inapropiate word
+ - `uninapword [phrase]` - Remove an inapropiate word
+ - `viw` - View inapropiate words list
+
+**Joinphrases:** Configure what phrase Bot says when certain user joins a room. This can be spammable, much caution!
+ - `joinphrase [enable/disable]` - Enable or disable joinphrases for a room
+ - `joinphrase set, [user], [phrase]` - Set a joinphrase
+ - `joinphrase delete, [user]` - Remove a joinphrase
+ - `vjf` - View joinphrases list
+ 
+**Note:** Excepted users can use moderation commands in format `command [roomid]Arguments` to set moderation through PM or other room. Example: `ab [lobby]spammer1, spammer2`
+
+Configuration
+------------
+
+ - `modException`- Minimum rank to avoid bot moderation
+ - `allowmute` - Enable or disable moderation
+ - `disableModNote` - True for disabling the modnote on autoban command
+ - `MOD_CONSTS` - Constants for flood, caps and stretching
+ - `modDefault` - Default config for moderation (0 to disable, 1 to enable)
+ - `punishments` - Punishments list (warn, mute, hormute, roomban)
+ - `zeroToleranceDefaultLevel` - Default level for Zero Tolerance feature
+ - `zeroToleranceLevels` - Levels for Zero Tolerance feature
+
+```js
+exports.moderation = {
+	modException: '%', // Min rank for not receive moderation
+
+	allowmute: true,
+	disableModNote: false,
+
+	MOD_CONSTS: {
+		FLOOD_MESSAGE_NUM: 5,
+		FLOOD_PER_MSG_MIN: 500, // this is the minimum time between messages for legitimate spam. It's used to determine what "flooding" is caused by lag
+		FLOOD_MESSAGE_TIME: 6 * 1000,
+
+		MIN_CAPS_LENGTH: 18,
+		MIN_CAPS_PROPORTION: 0.8,
+
+		MAX_STRETCH: 7,
+		MAX_REPEAT: 4
+	},
+
+	modDefault: {
+		//basic mods
+		'caps': 1,
+		'stretching': 1,
+		'flooding': 1,
+		'spam': 1,
+
+		'bannedwords': 1,
+		'inapropiate': 1,
+
+		//specific mods
+		'spoiler': 0,
+		'youtube': 0,
+		'psservers': 1,
+
+		//multiple infraction
+		'multiple': 1,
+
+		//zero tolerance
+		'zerotol': 1
+	},
+
+	punishments: [
+		"warn",
+		"mute",
+		"hourmute",
+		"roomban"
+	],
+
+	psServersExcepts: {
+		"showdown": 1,
+		"smogtours": 1
+	},
+
+	zeroToleranceDefaultLevel: 'h',
+	zeroToleranceLevels: {
+		'l': {name: 'Low', value: 1},
+		'n': {name: 'Normal', value: 2},
+		'h': {name: 'High', value: 3}
+	}
+};
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ var globalList = [
 	'Bot', 'CommandParser', 'Config', 'DataDownloader', 'Features', 'Formats', 'Settings', 'Tools',
 	'colors', 'sys', 'fs', 'path', 'PSClient',
 	'reloadConfig', 'reloadFeatures',
-	'toId', 'ok', 'info', 'error', 'errlog', 'debug', 'cmdr', 'recv', 'sent', 'monitor'
+	'toId', 'toRoomid', 'ok', 'info', 'error', 'errlog', 'debug', 'cmdr', 'recv', 'sent', 'monitor'
 ];
 globalList.forEach(function (identifier) {globals[identifier] = false;});
 

--- a/languages/english.js
+++ b/languages/english.js
@@ -311,6 +311,27 @@ exports.translations = {
 			'listrab': 'The following regexes are banned in',
 			'err': 'upload failure, could not upload blacklist to hastebin'
 		},
+		zerotol: {
+			'nolevels': 'There are not any zero tolerance levels',
+			'user': 'User',
+			'level': 'Level',
+			'ztl': 'Zero tolerance list',
+			'empty': 'Zero tolerance list is empty',
+			'is': 'is',
+			'n': 'NOT',
+			'y': '',
+			'in': 'in the zero tolerance list',
+			'u1': 'Usage',
+			'u2': '[add/delete], [User1:level]...',
+			'users': 'User(s)',
+			'add': 'added to the zero tolerance list',
+			'illegal': 'users had illegal nicks',
+			'invalid': 'had invalid levels',
+			'already': 'were already present in the list',
+			'removed': 'removed from the zero tolerance list',
+			'not': 'users were not present in the list',
+			'err': 'upload failure, could not upload zero tolerance list to hastebin'
+		},
 		banword: {
 			'notchat': 'This command is only available for chat rooms',
 			'phrase': 'Phrase',

--- a/languages/english.js
+++ b/languages/english.js
@@ -312,16 +312,19 @@ exports.translations = {
 			'err': 'upload failure, could not upload blacklist to hastebin'
 		},
 		banword: {
+			'notchat': 'This command is only available for chat rooms',
 			'phrase': 'Phrase',
 			'already': 'is already banned.',
 			'ban': 'is now banned.'
 		},
 		unbanword: {
+			'notchat': 'This command is only available for chat rooms',
 			'phrase': 'Phrase',
 			'not': 'is not currently banned.',
 			'unban': 'is no longer banned.'
 		},
 		viewbannedwords: {
+			'notchat': 'This command is only available for chat rooms',
 			'in': 'in',
 			'globally': 'globally',
 			'phrase': 'Phrase',
@@ -334,16 +337,19 @@ exports.translations = {
 			'err': 'upload failure, could not upload banwords to hastebin'
 		},
 		inapword: {
+			'notchat': 'This command is only available for chat rooms',
 			'phrase': 'Phrase',
 			'already': 'is already inapropiate.',
 			'ban': 'is now inapropiate.'
 		},
 		uninapword: {
+			'notchat': 'This command is only available for chat rooms',
 			'phrase': 'Phrase',
 			'not': 'is not currently inapropiate.',
 			'unban': 'is no longer inapropiate.'
 		},
 		viewinapwords: {
+			'notchat': 'This command is only available for chat rooms',
 			'in': 'in',
 			'globally': 'globally',
 			'phrase': 'Phrase',
@@ -356,6 +362,7 @@ exports.translations = {
 			'err': 'upload failure, could not upload inapropiate phrases to hastebin'
 		},
 		joinphrase: {
+			'notchat': 'This command is only available for chat rooms',
 			'ae': 'Join phrases already enabled for this room',
 			'e': 'Join phrases are now enabled for this room"',
 			'ad': 'Join phrases already disabled for this room"',
@@ -371,6 +378,7 @@ exports.translations = {
 			'not': 'does not exists'
 		},
 		viewjoinphrases: {
+			'notchat': 'This command is only available for chat rooms',
 			'iu': 'Invalid username.',
 			'not': 'No Joinphrase set for',
 			'empty': 'There are not JoinPhrases in this room.',

--- a/languages/french.js
+++ b/languages/french.js
@@ -311,6 +311,27 @@
 			'listrab': 'Les expressions régulières suivantes sont interdites dans',
 			'err': 'Erreur : Je ne peux pas télécharger la liste noire sur hastebin'
 		},
+		zerotol: {
+			'nolevels': 'Il n\'y a pas de niveaux de tolérance zéro',
+			'user': 'Utilisateur',
+			'level': 'Niveau',
+			'ztl': 'Liste de tolérance zéro',
+			'empty': 'Zero tolerance list is empty',
+			'is': 'est actuellement',
+			'n': 'pas',
+			'y': '',
+			'in': 'sur le liste de tolérance zéro',
+			'u1': 'Usage',
+			'u2': '[add/delete], [Utilisateur:niveau]...',
+			'users': 'Utilisateur(s)',
+			'add': 'ajouté à la liste de tolérance zéro',
+			'illegal': 'utilisateurs avaient entailles illégales',
+			'invalid': 'avaient des niveaux invalides',
+			'already': 'étaient déjà présents dans la liste',
+			'removed': 'retiré de la liste de tolérance zéro',
+			'not': 'utilisateurs sont pas sur la liste',
+			'err': 'Erreur : Je ne peux pas télécharger la liste de tolérance zéro sur hastebin'
+		},
 		banword: {
 			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'phrase': 'Phrase',

--- a/languages/french.js
+++ b/languages/french.js
@@ -312,16 +312,19 @@
 			'err': 'Erreur : Je ne peux pas télécharger la liste noire sur hastebin'
 		},
 		banword: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'phrase': 'Phrase',
 			'already': 'est déjà interdite.',
 			'ban': 'est désormais interdite.'
 		},
 		unbanword: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'phrase': 'Phrase',
 			'not': 'n\'est pas actuellement interdite.',
 			'unban': 'a été débannie.'
 		},
 		viewbannedwords: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'in': 'dans',
 			'globally': 'globalement',
 			'phrase': 'Phrase',
@@ -334,16 +337,19 @@
 			'err': 'Erreur: Je ne peux pas télécharger banwords à hastebin'
 		},
 		inapword: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'phrase': 'Phrase',
 			'already': 'est déjà inappropriée.',
 			'ban': 'est maintenant inappropriée.'
 		},
 		uninapword: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'phrase': 'Phrase',
 			'not': 'est actuellement pas inappropriée.',
 			'unban': 'est maintenant plus inappropriée.'
 		},
 		viewinapwords: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'in': 'dans',
 			'globally': 'globalement',
 			'phrase': 'Phrase',
@@ -356,6 +362,7 @@
 			'err': 'Erreur : Je ne pouvais pas télécharger les phrases inappropriées sur hastebin'
 		},
 		joinphrase: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'ae': 'Ces phrases de connections sont déjà permis pour cette salle',
 			'e': 'Ces phrases de connections sont maintenant permis pour cette salle"',
 			'ad': 'Ces phrases de connections sont déjà désactivées pour cette salle"',
@@ -371,6 +378,7 @@
 			'not': 'n\'existe pas'
 		},
 		viewjoinphrases: {
+			'notchat': 'Cette commande est disponible seulement pour les salles de chat',
 			'iu': 'Nom d\'utilisateur invalide.',
 			'not': 'Aucune de ces phrases n\'est fixé pour',
 			'empty': 'Ce n\'est pas des phrases de connection dans cette salle.',

--- a/languages/italian.js
+++ b/languages/italian.js
@@ -311,6 +311,27 @@ exports.translations = {
 			'listrab': 'Le seguenti regex sono bannate in',
 			'err': 'upload fallito, impossibile caricare su hastebin'
 		},
+		zerotol: {
+			'nolevels': 'Non ci sono livelli di tolleranza zero',
+			'user': 'User',
+			'level': 'Livello',
+			'ztl': 'Lista di tolleranza zero',
+			'empty': 'Lista di tolleranza zero è vuoto',
+			'is': '',
+			'n': 'NON',
+			'y': '',
+			'in': 'nella lista di tolleranza zero',
+			'u1': 'Usage',
+			'u2': '[add/delete], [User:livello]...',
+			'users': 'User(s)',
+			'add': 'aggiunti alla lista di tolleranza zero',
+			'illegal': 'users aveva nick illegali',
+			'invalid': 'avevano livelli non validi',
+			'already': 'erano già nell\'elenco',
+			'removed': 'rimosso dalla lista di tolleranza zero',
+			'not': 'users non erano presenti nella lista',
+			'err': 'upload fallito, impossibile caricare su hastebin'
+		},
 		banword: {
 			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'phrase': 'La frase',

--- a/languages/italian.js
+++ b/languages/italian.js
@@ -312,16 +312,19 @@ exports.translations = {
 			'err': 'upload fallito, impossibile caricare su hastebin'
 		},
 		banword: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'phrase': 'La frase',
 			'already': 'è già bannata.',
 			'ban': 'è ora banned.'
 		},
 		unbanword: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'phrase': 'La frase',
 			'not': 'non è bannata.',
 			'unban': 'non è più bannata.'
 		},
 		viewbannedwords: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'in': 'in',
 			'globally': 'globalmente',
 			'phrase': 'La frase',
@@ -334,16 +337,19 @@ exports.translations = {
 			'err': 'upload fallito, impossibile caricare su hastebin'
 		},
 		inapword: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'phrase': 'La frase',
 			'already': 'è già inappropriata.',
 			'ban': 'è ora inappropriata.'
 		},
 		uninapword: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'phrase': 'La frase',
 			'not': 'è al momento non inappropriata.',
 			'unban': 'non è più inappropriata.'
 		},
 		viewinapwords: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'in': 'in',
 			'globally': 'globalmente',
 			'phrase': 'La frase',
@@ -356,6 +362,7 @@ exports.translations = {
 			'err': 'upload fallito, impossibile caricare su hastebin'
 		},
 		joinphrase: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'ae': 'Greetings già abilitate',
 			'e': 'Greeting ora abilitate',
 			'ad': 'Greetings già disabilitate',
@@ -371,6 +378,7 @@ exports.translations = {
 			'not': 'non esiste'
 		},
 		viewjoinphrases: {
+			'notchat': 'Questo comando è disponibile solo nelle chat',
 			'iu': 'Nickname non valido.',
 			'not': 'Nessun greeting per',
 			'empty': 'Nessuna greet in questa room.',

--- a/languages/spanish.js
+++ b/languages/spanish.js
@@ -312,16 +312,19 @@
 			'err': 'Error: No se puede subir la lista negra a hastebin'
 		},
 		banword: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'phrase': 'La frase',
 			'already': 'ya estaba prohibida.',
 			'ban': 'está prohibida a partir de ahora.'
 		},
 		unbanword: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'phrase': 'La frase',
 			'not': 'no estaba prohibida.',
 			'unban': 'ha dejado de estar prohibida.'
 		},
 		viewbannedwords: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'in': 'en',
 			'globally': 'globalmente',
 			'phrase': 'La frase',
@@ -334,16 +337,19 @@
 			'err': 'Error: no se puede subir la lista de frases prohibidas a hastebin'
 		},
 		inapword: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'phrase': 'La frase',
 			'already': 'ya era inapropiada.',
 			'ban': 'es inapropiada a partir de ahora.'
 		},
 		uninapword: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'phrase': 'La frase',
 			'not': 'no era inapropiada.',
 			'unban': 'ha dejado de ser inapropiada.'
 		},
 		viewinapwords: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'in': 'en',
 			'globally': 'globalmente',
 			'phrase': 'La frase',
@@ -356,6 +362,7 @@
 			'err': 'Error: no se puede subir la lista de frases inapropiadas a hastebin'
 		},
 		joinphrase: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'ae': 'Ls frases de entrada ya estaban activadas en esta sala',
 			'e': 'Las frases de entrada han sido habilitadas para esta sala"',
 			'ad': 'Las frases de entrada ya estaban deshabilitadas para esta sala"',
@@ -371,6 +378,7 @@
 			'not': 'no existe'
 		},
 		viewjoinphrases: {
+			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'iu': 'Nombre de usuario incorrecto.',
 			'not': 'No hay frase de entrada para',
 			'empty': 'No hay frases de entrada en esta sala.',

--- a/languages/spanish.js
+++ b/languages/spanish.js
@@ -311,6 +311,27 @@
 			'listrab': 'Las siguientes expresiones regulares están en la lista negra de la sala',
 			'err': 'Error: No se puede subir la lista negra a hastebin'
 		},
+		zerotol: {
+			'nolevels': 'No hay niveles de tolerancia cero disponibles',
+			'user': 'Usuario',
+			'level': 'Nivel',
+			'ztl': 'Lista de tolerancia cero',
+			'empty': 'La lista de tolerancia zero está vacía',
+			'is': '',
+			'n': 'NO ESTA',
+			'y': 'Sí ESTA',
+			'in': 'presente en la lista de tolerancia cero',
+			'u1': 'Uso correcto',
+			'u2': '[add/delete], [Usuario:nivel]...',
+			'users': 'Usuario(s)',
+			'add': 'agregado(s) a la lista de tolerancia cero',
+			'illegal': 'usuarios tenían nicks ilegales',
+			'invalid': 'tenían niveles no válidos',
+			'already': 'ya estaban presentes en la lista',
+			'removed': 'eliminado(s) correctamente de la lista de tolerancia cero',
+			'not': 'usuarios no etaban en la lista',
+			'err': 'Error: no se puede subir la lista de tolerancia cero a hastebin'
+		},
 		banword: {
 			'notchat': 'Este comando solo está disponible para las salas de chat',
 			'phrase': 'La frase',

--- a/tools.js
+++ b/tools.js
@@ -5,6 +5,10 @@ global.toId = function (text) {
 	return text.toLowerCase().replace(/[^a-z0-9]/g, '');
 };
 
+global.toRoomid = function (roomid) {
+	return roomid.replace(/[^a-zA-Z0-9-]+/g, '').toLowerCase();
+};
+
 global.ok = function (str) {
 	if (Config.debug && Config.debug.ok === false) return;
 	console.log('ok'.green + '\t' + str);


### PR DESCRIPTION
Improve **Moderation** feature:
 - Support cross-room commands (Example: `.ab [lobby]Troll 1, Troll 2`) for bot excepted users. (Done)
 - Remove constants for flood, caps and stretching to make them configurable. (Done)
 - Support a permanent zero tolerance list.
 - Write moderation documentation.

This is still in progress, will be finished soon.