### PR TITLE
GitHub: Use /addhtmlbox instead of !htmlbox

### DIFF
--- a/features/github/index.js
+++ b/features/github/index.js
@@ -8,7 +8,7 @@ var updates = exports.updates = {};
 
 function report (str) {
 	debug("GitHub: " + str);
-	if (Config.github) Bot.say(Config.github.room, "!htmlbox " + str);
+	if (Config.github) Bot.say(Config.github.room, "/addhtmlbox " + str);
 }
 
 function startWebHook (secret, port) {


### PR DESCRIPTION
Since the bot would need at least Room Bot to use !htmlbox anyways, let the bot use the bot-given /addhtmlbox command. This command is also used on xfix's GitHub bot, where the inspiration for this came from.