### PR TITLE
Change HTTP to HTTPS

### DIFF
--- a/commands/features-battle.js
+++ b/commands/features-battle.js
@@ -202,10 +202,10 @@ exports.commands = {
 				if (!link) return this.reply(this.trad('u1') + ': ' + this.cmdToken + cmd + ' ' + this.trad('u2'));
 				if (link.substr(-1) === '/') link = link.substr(0, link.length - 1);
 				var splitedLink = link.split('/');
-				link = 'http://hastebin.com/raw/' + splitedLink[splitedLink.length - 1];
+				link = 'https://hastebin.com/raw/' + splitedLink[splitedLink.length - 1];
 				if (!Formats[format]) return this.reply(this.trad('format') + " __" + format + "__ " + this.trad('notexists'));
 				this.reply(this.trad('download') + '... (' + link + ')');
-				var http = require('http');
+				var http = require('https');
 				http.get(link, function (res) {
 					var data = '';
 					res.on('data', function (part) {


### PR DESCRIPTION
Whenever I add a team with this bot, I check if the team copied into the bot's `teams.json` but whenever I view the JSON file, the team that I had uploaded into the bot's team database via `.teams add, [name], [tier], [hastebin link]` didn't copy the team at all. When I had a look between hastebin and `features-battle.js`, I had found out that the file rather uses `http` than `https` as hastebin is linked as [https://hastebin.com/]. Hence, why I am sending a pull request to fix this error in adding teams. 
